### PR TITLE
Add ability to update root domain name

### DIFF
--- a/datatypes/payload.go
+++ b/datatypes/payload.go
@@ -1,6 +1,8 @@
 package datatypes
 
-import "os"
+import (
+	"os"
+)
 
 // Payload wraps all required data to successfully execute a CF API DDNS A record update
 type Payload struct {
@@ -17,6 +19,9 @@ type Payload struct {
 
 // FQDN returns the FQDN
 func (p Payload) FQDN() string {
+	if "@" == p.DNSRecord {
+		return p.Zone
+	}
 	return p.DNSRecord + "." + p.Zone
 }
 


### PR DESCRIPTION
Currently is not possible to update domain root A record due to DNS FQDN method implementation.

I extended the FQDN method resolver to return zone name if @ is provided as a value for X_CF_AGENT_DNS_A_RECORD env var.
@ is used in Cloudflare console to reference root so follow the same pattern here also.